### PR TITLE
add `karate` jbang alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ This is the [React TodoMVC](http://todomvc.com/examples/react/) sample re-writte
 
 ## Running Locally
 * clone this repository: `git clone https://github.com/ptrthomas/karate-todomvc.git` or [download a ZIP](https://github.com/ptrthomas/karate-todomvc/archive/main.zip)
-* download `karate-0.9.9.RC2.jar` from [here](https://dl.bintray.com/ptrthomas/karate/) (or use jbang, see below)
-* rename it to `karate.jar`, place it in the same folder as the files from git
-* Java (only a [JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html) is needed)
-  * `java -jar karate.jar -S`
-* Docker
+* Use [jbang](https://jbang.dev)
+  * if jbang installed run: `jbang serve`
+  * if not installed: `curl -Ls https://sh.jbang.dev | bash -s - karate -S`
+* Manually:
+  * Download `karate-0.9.9.RC2.jar` from [here](https://dl.bintray.com/ptrthomas/karate/) (or use jbang, see below)
+  * rename it to `karate.jar`, place it in the same folder as the files from git
+  * Java (only a [JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html) is needed)
+    * `java -jar karate.jar -S`
+* or Docker
   * `docker run --rm -v "$PWD":/src -w /src -p 8080:8080 openjdk:8 java -jar karate.jar -S`
-* [jbang](https://www.jbang.dev)
-  * `jbang com.intuit.karate:karate-core:0.9.9.RC2 -S`
 * navigate to [http://localhost:8080](http://localhost:8080) to view the app
 * you can add `-p` to change the port number if needed e.g. `-p 8000`

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,8 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "karate": {
+      "script-ref": "com.intuit.karate:karate-core:0.9.9.RC2"
+    }
+  }
+}


### PR DESCRIPTION
This adds a `jbang-catalog.json` which enables you to
do just `jbang karate -S`.

I took the liberty to update the readme as then you don't
need all the others steps as `jbang` will download the necessary
parts.